### PR TITLE
add 4 new scripts to be used for installing gtoolkit-remote into a 3.7.1 or 3.7.1.4 gemstone rowan3 extent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ github-*.zip
 
 # vi swap files
 *.swp
+*.swo

--- a/scripts/convertToGsFormat_rowan3.sh
+++ b/scripts/convertToGsFormat_rowan3.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+### Export gtoolkit-remote to a .gs file.
+### Requires loginSystemUser.topaz be configured with the correct credentials.
+### Exits with 0 if success, topaz status if failed.
+
+set -e
+
+if [ -z "$ROWAN_PROJECTS_HOME" ]
+then
+	echo "ROWAN_PROJECTS_HOME must be defined"
+	exit 1
+fi
+
+if [ -z "$STONE" ]
+then
+	echo "STONE must be defined"
+	exit 1
+fi
+
+repositoryDir=${ROWAN_PROJECTS_HOME}/gtoolkit-remote
+## Topaz refuses to exit from script if input is stdin, so redirect from /dev/zero
+topaz -l -I ${repositoryDir}/scripts/loginSystemUser.topaz  -S ${repositoryDir}/scripts/convertToGsFormat_rowan3.topaz < /dev/zero
+status=$?
+if [ $status != 0 ]
+then
+        echo !!!!!!!!!!!!!!!!
+        echo Failed to export $repositoryDir
+        echo !!!!!!!!!!!!!!!!
+        exit $status
+fi
+
+exit 0

--- a/scripts/convertToGsFormat_rowan3.topaz
+++ b/scripts/convertToGsFormat_rowan3.topaz
@@ -1,0 +1,46 @@
+	iferr 1 stk
+	iferr 2 stack
+	iferr 3 exit
+
+	expectvalue true
+	run
+| warnings projectSetModification visitor gsDirectory project repositoryRoot projectSetDefinition  |
+warnings := String new.
+
+	repositoryRoot := '$ROWAN_PROJECTS_HOME/gtoolkit-remote'.
+	gsDirectory := repositoryRoot asFileReference / 'src-gs'.
+	project := Rowan 
+		projectFromUrl: 'file:', repositoryRoot, '/rowan/specs/gtoolkit-remote.ston'
+		gitUrl: 'file:', repositoryRoot.
+	projectSetDefinition := RwProjectSetDefinition new
+		addProject: project _concreteProject;
+		yourself.
+	projectSetModification := projectSetDefinition compareAgainstBase: RwProjectSetDefinition new.
+
+	projectSetModification findAddedMethods values do: [ :each |
+		each methodsModification elementsModified values do: [ :another | 
+			another after protocol: another after protocol asString ] ].
+
+	projectSetModification findAddedClasses values do: [ :each |
+		each classesModification elementsModified values collect: [ :another | 
+			another after instanceMethodDefinitions values do: [ :aMethodDefinition |
+				aMethodDefinition protocol: aMethodDefinition protocol asString ].
+			another after classMethodDefinitions values do: [ :aMethodDefinition |
+				aMethodDefinition protocol: aMethodDefinition protocol asString ] ] ].
+
+	visitor := RwGsModificationTopazWriterVisitorV2 new
+		logCreation: true;
+		repositoryRootPath: gsDirectory;
+		topazFilename: 'gtoolkit-remote';
+		yourself.
+	visitor visit: projectSetModification.
+
+
+warnings isEmpty
+	ifTrue: [ true ]
+	ifFalse: [ warnings ]
+%
+	abort
+
+	errorCount
+	exit

--- a/scripts/installGtoolkitRemote.sh
+++ b/scripts/installGtoolkitRemote.sh
@@ -2,6 +2,20 @@
 ### Install gtoolkit-remote from Tonel files into a Rowan-enabled stone
 ### Exits with 0 if success, 1 if failed
 
+set -e
+
+if [ -z "$ROWAN_PROJECTS_HOME" ]
+then
+	echo "ROWAN_PROJECTS_HOME must be defined"
+	exit 1
+fi
+
+if [ -z "$STONE" ]
+then
+	echo "STONE must be defined"
+	exit 1
+fi
+
 gt4GemstoneHome=${ROWAN_PROJECTS_HOME}/gtoolkit-remote
 ## Topaz refuses to exit from script if input is stdin, so redirect from /dev/zero
 topaz -l -I ${gt4GemstoneHome}/scripts/loginSystemUser.topaz  -S ${gt4GemstoneHome}/scripts/installGtoolkit-remote.topaz < /dev/zero

--- a/scripts/installGtoolkitRemote_rowan3_jfp.sh
+++ b/scripts/installGtoolkitRemote_rowan3_jfp.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+### Install gtoolkit-remote from Tonel files into a Rowan-enabled stone
+### Exits with 0 if success, 1 if failed
+
+gt4GemstoneHome=${ROWAN_PROJECTS_HOME}/gtoolkit-remote
+## Topaz refuses to exit from script if input is stdin, so redirect from /dev/zero
+topaz -l -I ${gt4GemstoneHome}/scripts/loginSystemUser.topaz  -S ${gt4GemstoneHome}/scripts/installGtoolkit-remote.topaz < /dev/zero
+if [ $? = 0 ]
+    then
+        echo gtoolkit-remote loaded, now updating Rowan3 extent for use with JfP
+    else
+        echo !!!!!!!!!!!!!!
+        echo INSTALL FAILED for gtoolkit-remote
+        echo !!!!!!!!!!!!!!
+        exit 1
+    fi
+
+## Update for 3.7.1 and 3.7.1.4 Rowan 3 image and JadeiteForPharo
+#
+## Topaz refuses to exit from script if input is stdin, so redirect from /dev/zero
+topaz -l -I ${gt4GemstoneHome}/scripts/loginSystemUser.topaz  -S ${gt4GemstoneHome}/scripts/updateForRowan3_JfP-gemstone.topaz < /dev/zero
+if [ $? = 0 ]
+    then
+        exit 0
+    else
+        echo !!!!!!!!!!!!!!
+        echo INSTALL FAILED for Rowan 3 JfP update
+        echo !!!!!!!!!!!!!!
+        exit 1
+    fi
+

--- a/scripts/loginSystemUser.topaz
+++ b/scripts/loginSystemUser.topaz
@@ -1,5 +1,5 @@
 ## Edit this for your stone name and authentication.
 ## The installation and bootstrap scripts in this directory must use the SystemUser login.
-set gemstone gs64stone
+set gemstone $STONE
 set user SystemUser pass swordfish
 login

--- a/scripts/updateForRowan3_JfP-gemstone.topaz
+++ b/scripts/updateForRowan3_JfP-gemstone.topaz
@@ -1,0 +1,50 @@
+	iferr 1 stk
+	iferr 2 stack
+	iferr 3 exit
+
+	expectvalue true
+	run
+| warnings rowanProjectsHome |
+warnings := String new.
+rowanProjectsHome := '$ROWAN_PROJECTS_HOME'.
+[
+	"update RowanClientServices:mainV3.0 [3d1ae497b] (as of 9/5/24) -- REQUIRED for JfP"
+true ifTrue: [ 
+	"temporary patch to ensure 'mainV3.0' branch is used"
+	| spec |
+	spec := RwSpecification fromUrl: 'https://raw.githubusercontent.com/GemTalk/RowanClientServices/masterV3.0/rowan/specs/RowanClientServices.ston'.
+	spec 
+		revision: 'mainV3.0';
+		projectsHome: rowanProjectsHome;
+		load
+] ifFalse: [
+	(Rowan projectFromUrl: 'https://raw.githubusercontent.com/GemTalk/RowanClientServices/masterV3.0/rowan/specs/RowanClientServices.ston')
+		projectsHome: rowanProjectsHome;
+		load ].
+
+	"update RemoteServiceReplication:main [04f33cab2] (as of 9/5/24) -- REQUIRED for JfP"
+true ifTrue: [ 
+	"temporary patch to ensure 'main' branch is used"
+	| spec |
+	spec := RwSpecification fromUrl: 'https://raw.githubusercontent.com/GemTalk/RemoteServiceReplication/main/rowan/specs/RemoteServiceReplication.ston'.
+	spec 
+		revision: 'main';
+		projectsHome: rowanProjectsHome;
+		load
+] ifFalse: [
+	(Rowan projectFromUrl: 'https://raw.githubusercontent.com/GemTalk/RemoteServiceReplication/main/rowan/specs/RemoteServiceReplication.ston')
+		projectsHome: rowanProjectsHome;
+		load.
+] ] on: CompileWarning do: [:ex |
+	(ex description includesString: 'not optimized')
+			ifFalse: [ warnings 
+                           addAll: ex asString;
+                           lf ].
+	ex resume ].
+warnings isEmpty
+	ifTrue: [ true ]
+	ifFalse: [ warnings ]
+%
+	commit
+
+	errorCount


### PR DESCRIPTION
updateForRowan3_JfP-gemstone.topaz is used to update RowanClientServices and RemoteServiceReplication in the stone. It is called by the new installGtoolkitRemote_rowan3_jfp.sh script. The new versions of RowanClientServices and RemoteServiceReplication are needed by JadeiteForPharo (JfP).

convertToGsFormat_rowan3.topaz contains a modification to the script for use with Rowan 3 and is called by convertToGsFormat_rowan3.sh.

The scripts have been tested with 3.7.1 and 3.7.1.4 ... and the latest [JadeiteForPharo](https://github.com/GemTalk/JadeiteForPharo).

Here are the SHAS of the JadeiteForPharo projects I was using:
```
JadeiteForPharo 06ee1e8
PharoGemStoneFFI 3575de4
RemoteServiceReplication 04f33ca
---------------------------------------------
RowanClientServices 3d1ae49
```